### PR TITLE
export only lower-case names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterHandling"
 uuid = "2412ca09-6db7-441c-8e3a-88d5709968c5"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -3,7 +3,7 @@ module ParameterHandling
 using Bijectors
 using Compat: only
 
-export flatten, Positive, Bounded, Fixed, Deferred
+export flatten, positive, bounded, fixed, deferred
 
 include("flatten.jl")
 include("parameters.jl")

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -8,6 +8,8 @@ using ParameterHandling: Positive, Bounded
             test_parameter_interface(p)
             @test value(p) ≈ val
         end
+
+        @test_throws ArgumentError positive(-0.1)
     end
 
     @testset "bounded" begin
@@ -16,6 +18,8 @@ using ParameterHandling: Positive, Bounded
             test_parameter_interface(bounded(-0.05, -0.1, 2.0))
             @test value(p) ≈ val
         end
+
+        @test_throws ArgumentError bounded(-0.05, 0.0, 1.0)
     end
 
     @testset "fixed" begin

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -1,37 +1,38 @@
+using ParameterHandling: Positive, Bounded
+
 @testset "parameters" begin
 
-    @testset "Postive" begin
-        test_parameter_interface(Positive(5.0))
-        p = Positive(-10.0)
-        @test value(p) > p.ε
-        p = Positive(-Inf)
-        @test value(p) == p.ε
+    @testset "postive" begin
+        @testset "$val" for val in [5.0, 1e-11, 1e-12]
+            p = positive(val)
+            test_parameter_interface(p)
+            @test value(p) ≈ val
+        end
     end
 
-    @testset "Bounded" begin
-        test_parameter_interface(Bounded(-1.0, -0.1, 2.0))
-        p = Bounded(-10.0, -0.1, 2.0)
-        @test value(p) > p.lower_bound
-        p = Bounded(-Inf, -0.1, 2.0)
-        @test value(p) == p.lower_bound + p.ε
-        p = Bounded(10.0, -0.1, 2.0)
-        @test value(p) < p.upper_bound
-        p = Bounded(Inf, -0.1, 2.0)
-        @test value(p) == p.upper_bound - p.ε
+    @testset "bounded" begin
+        @testset "$val" for val in [-0.05, -0.1 + 1e-12, 2.0 - 1e-11, 2.0 - 1e-12]
+            p = bounded(val, -0.1, 2.0)
+            test_parameter_interface(bounded(-0.05, -0.1, 2.0))
+            @test value(p) ≈ val
+        end
     end
 
-    @testset "Fixed" begin
-        test_parameter_interface(Fixed((a=5.0, b=4.0)))
+    @testset "fixed" begin
+        val = (a=5.0, b=4.0)
+        p = fixed(val)
+        test_parameter_interface(p)
+        @test value(p) == val
     end
 
-    @testset "Deferred" begin
-        test_parameter_interface(Deferred(sin, 0.5))
-        test_parameter_interface(Deferred(sin, Positive(log(0.5))))
+    @testset "deferred" begin
+        test_parameter_interface(deferred(sin, 0.5))
+        test_parameter_interface(deferred(sin, positive(0.5)))
         test_parameter_interface(
-            Deferred(
+            deferred(
                 MvNormal,
-                Fixed(randn(5)),
-                Deferred(PDiagMat, Positive.(randn(5))),
+                fixed(randn(5)),
+                deferred(PDiagMat, positive.(rand(5) .+ 1e-1)),
             )
         )
     end
@@ -41,7 +42,7 @@
         return abs2(θ.a) + abs2(θ.b)
     end
 
-    # This is more of a worked example. Will be properly split up / tidied up.
+    # This is more of a worked example.
     @testset "Integration" begin
 
         θ0 = (a=5.0, b=4.0)
@@ -62,7 +63,7 @@
 
     @testset "Other Integration" begin
 
-        θ0 = (a=5.0, b=Fixed(4.0))
+        θ0 = (a=5.0, b=fixed(4.0))
         flat_parameters, unflatten = flatten(θ0)
 
         results = Optim.optimize(
@@ -85,7 +86,7 @@
 
     @testset "Normal" begin
 
-        θ0 = Deferred(Normal, randn(), Positive(log(1.0)))
+        θ0 = deferred(Normal, randn(), positive(1.0))
         flat_parameters, unflatten = flatten(θ0)
 
         results = Optim.optimize(


### PR DESCRIPTION
When you make a `Parameter`, you typically want to specify the "constrained" value e.g. if you specify a `positive` value, you want to specify `1.0`, not `log(1.0)`. That being said, we need to be able to be able to construct via the unconstrained value so that `unflatten` can be made to work properly.

Therefore, the convention introduced in this PR is

1. if you're a user, use the lower-case name of the parameter. e.g. `positive` or `bounded` or `deferred`.
2. if you're writing `flatten` for a parameter, use the upper-case name to avoid re-computing things. e.g. `Positive` or `Bounded` or `Deferred`.