### PR TITLE
Use InverseFunctions and LogExpFunctions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,17 +4,19 @@ authors = ["Invenia Technical Computing Corporation"]
 version = "0.3.8"
 
 [deps]
-Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Bijectors = "0.8, 0.9"
 ChainRulesCore = "0.9, 0.10, 1"
 Compat = "3"
+InverseFunctions = "0.1"
 IterTools = "1.3"
+LogExpFunctions = "0.3"
 julia = "1.3"

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ _unconstrained_ number, rather than the value represented by the `Positive` obje
 example
 
 ```julia
-julia> using ParameterHandling: value, Positive
+julia> using ParameterHandling
 
-julia> x_unconstrained = log(1.0) # Specify unconstrained value.
-0.0
+julia> x_constrained = 1.0 # Specify constrained value.
+1.0
 
-julia> x = Positive(x_unconstrained) # Construct a number that should remain positive.
-Positive{Float64,Bijectors.Exp{0}}(0.0, Bijectors.Exp{0}())
+julia> x = positive(x_constrained) # Construct a number that should remain positive.
+ParameterHandling.Positive{Float64, typeof(exp), Float64}(-1.490116130486996e-8, exp, 1.4901161193847656e-8)
 
 julia> value(x) # Get the constrained value by applying the transform.
 1.0
@@ -152,23 +152,23 @@ julia> value(x) # Get the constrained value by applying the transform.
 julia> v, unflatten = flatten(x); # Supports the `flatten` interface.
 
 julia> v
-1-element Array{Float64,1}:
- 0.0
+1-element Vector{Float64}:
+ -1.490116130486996e-8
 
 julia> new_v = randn(1) # Pick a random new value.
-1-element Array{Float64,1}:
- 1.1220600582508566
+1-element Vector{Float64}:
+ 2.3482666974328716
 
 julia> value(unflatten(new_v)) # Obtain constrained value.
-3.071174489325673
+10.467410816707215
 ```
 
-We also provide the utility function `value_flatten` which returns un unflattening function
+We also provide the utility function `value_flatten` which returns an unflattening function
 equivalent to `value(unflatten(v))`. The above could then be implemented as
 ```julia
 julia> v, unflatten = value_flatten(x);
 
-julia> unflatten(x)
+julia> unflatten(v)
 1.0
 ```
 

--- a/src/ParameterHandling.jl
+++ b/src/ParameterHandling.jl
@@ -1,8 +1,9 @@
 module ParameterHandling
 
-using Bijectors
 using Compat: only
 using ChainRulesCore
+using InverseFunctions: inverse
+using LogExpFunctions: logit, logistic
 using LinearAlgebra
 using SparseArrays
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-Bijectors = "76274a88-744f-5084-9051-94815aaf08c4"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"

--- a/test/parameters.jl
+++ b/test/parameters.jl
@@ -16,7 +16,7 @@ pdiagmat(args...) = PDiagMat(args...)
         # Test edge cases around the size of the value relative to the error tol.
         @test_throws ArgumentError positive(-0.1)
         @test_throws ArgumentError positive(1e-11)
-        @test value(positive(1e-11, Bijectors.Exp(), 1e-12)) ≈ 1e-11
+        @test value(positive(1e-11, exp, 1e-12)) ≈ 1e-11
     end
 
     @testset "bounded" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,3 @@
-using Bijectors
 using Compat: only
 using ChainRulesTestUtils
 using Distributions


### PR DESCRIPTION
This PR replaces the Bijectors dependency with the more lightweight dependencies on InverseFunctions (for `inverse`) and LogExpFunctions (for `logit` and `logistic`).

InverseFunctions (https://github.com/JuliaMath/InverseFunctions.jl/) defines `InverseFunctions.inverse` as an interface for inverses of bijective functions and implements it for base functions such as `exp` and `log`. It is planned to implement it in other packages such as LogExpFunctions as well which would allow users to use eg. `LogExpFunctions.log1pexp` instead of the standard `exp` transform in `positive`.

Fixes https://github.com/invenia/ParameterHandling.jl/issues/24.