### PR TITLE
Relax orthogonal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ParameterHandling"
 uuid = "2412ca09-6db7-441c-8e3a-88d5709968c5"
 authors = ["Invenia Technical Computing Corporation"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -5,7 +5,7 @@ Project `X` onto the closest orthogonal matrix in Frobenius norm.
 
 Originally used in varz: https://github.com/wesselb/varz/blob/master/varz/vars.py#L446
 """
-@inline function nearest_orthogonal_matrix(X::StridedMatrix{<:Union{Real,Complex}})
+@inline function nearest_orthogonal_matrix(X::AbstractMatrix{<:Union{Real,Complex}})
     # Inlining necessary for type inference for some reason.
     U, _, V = svd(X)
     return U * V'
@@ -22,9 +22,9 @@ Frobenius norm) and is overparametrised as a consequence.
 
 Originally used in varz: https://github.com/wesselb/varz/blob/master/varz/vars.py#L446
 """
-orthogonal(X::StridedMatrix{<:Real}) = Orthogonal(X)
+orthogonal(X::AbstractMatrix{<:Real}) = Orthogonal(X)
 
-struct Orthogonal{TX<:StridedMatrix{<:Real}} <: AbstractParameter
+struct Orthogonal{TX<:AbstractMatrix{<:Real}} <: AbstractParameter
     X::TX
 end
 
@@ -46,7 +46,7 @@ be a positive-definite matrix (see https://en.wikipedia.org/wiki/Definite_matrix
 
 The unconstrained parameter is a `LowerTriangular` matrix, stored as a vector.
 """
-function positive_definite(X::StridedMatrix{<:Real})
+function positive_definite(X::AbstractMatrix{<:Real})
     isposdef(X) || throw(ArgumentError("X is not positive-definite"))
     return PositiveDefinite(tril_to_vec(cholesky(X).L))
 end

--- a/src/parameters_matrix.jl
+++ b/src/parameters_matrix.jl
@@ -1,5 +1,5 @@
 """
-    nearest_orthogonal_matrix(X::StridedMatrix)
+    nearest_orthogonal_matrix(X::AbstractMatrix{<:Union{Real,Complex}})
 
 Project `X` onto the closest orthogonal matrix in Frobenius norm.
 
@@ -12,7 +12,7 @@ Originally used in varz: https://github.com/wesselb/varz/blob/master/varz/vars.p
 end
 
 """
-    orthogonal(X::StridedMatrix{<:Real})
+    orthogonal(X::AbstractMatrix{<:Real})
 
 Produce a parameter whose `value` is constrained to be an orthogonal matrix. The argument `X` need not
 be orthogonal.
@@ -39,7 +39,7 @@ function flatten(::Type{T}, X::Orthogonal) where {T<:Real}
 end
 
 """
-    positive_definite(X::StridedMatrix{<:Real})
+    positive_definite(X::AbstractMatrix{<:Real})
 
 Produce a parameter whose `value` is constrained to be a positive-definite matrix. The argument `X` needs to
 be a positive-definite matrix (see https://en.wikipedia.org/wiki/Definite_matrix).


### PR DESCRIPTION
One issue with this I've found recently revisiting `orthogonal` is that it restricts wrapper arrays. As an example, present internal pipelines use `AxisKeys` and `NamedDims` - however the `StridedArray` restriction prevents this: 

```
using ParameterHandling: value, flatten

A = NamedDimsArray{(:id, :_)}(rand(5,5));

orthogonal(A)
ERROR: MethodError: no method matching orthogonal(::NamedDimsArray{(:id, :_), Float64, 2, Matrix{Float64}})
Closest candidates are:
  orthogonal(::StridedMatrix{var"#s3"} where var"#s3"<:Real) at /Users/alexrobson/.julia/packages/ParameterHandling/AGJx1/src/parameters.jl:181
```

Rewriting orthgonal to allow for abstractmatrix allows this to work:

```
using NamedDims, ParameterHandling

A = NamedDimsArray{(:id, :_)}(rand(5,5));

v, unflatten = flatten(orthogonal(A));

unflatten(v) # ParameterHandling.Orthogonal{NamedDimsArray{(:id, :_), Float64, 2, Matrix{Float64}}
```

With a nod to #22 AFAICT only `flatten` needs to be specialised? 
